### PR TITLE
Adding Height by Audio Level

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ You can also tweak the script to taste if you want to adjust how your file is ge
 - `Bounce+Shutter`: The simultaneous effects of `Bounce` and `Shutter`, slightly offset from each other.
 - `Sporadic`: The video glitches and wobbles randomly.
 - `Shrink`: The video shrinks vertically until it's just one pixel thin.
+- `Audiophile`: The video's vertical height changes relative to the current audio level verses the highest within the video.

--- a/wackywebm.js
+++ b/wackywebm.js
@@ -86,9 +86,9 @@ async function getAudioLevelMap() {
 	const intermediateMap = rawAudioData.map(({ tags: { "lavfi.astats.Overall.RMS_level": dBs } }, i) => ({ frame: Number(i + 1), dBs: resolveNumber(dBs) }))
 	// Obtain the highest audio level from the file.
 	const highest = intermediateMap.reduce((previous, current) => (previous.dBs > current.dBs ? previous : current))
-	//return map1.map(v => ({ percentMax: 1 - (highest.dBs / v.dBs), ...v })) // Shrink when louder.
+	//return intermediateMap.map(v => ({ percentMax: 1 - (highest.dBs / v.dBs), ...v })) // Shrink when louder.
 	// Amend percentages of the audio per frame vs. the highest in the file.
-	return map1.map(v => ({ percentMax: highest.dBs / v.dBs, ...v }))
+	return intermediateMap.map(v => ({ percentMax: highest.dBs / v.dBs, ...v }))
 }
 
 async function main() {
@@ -143,8 +143,8 @@ async function main() {
 		height = maxHeight,
 		length = tempFramesFrames.length
 	if (type.n === 99) {
-		type.map = await getAudioLevelMap()
-		type.mapN = type.map.length - 1
+		type.audioMap = await getAudioLevelMap()
+		type.audioMapL = type.audioMap.length - 1
 	}
 	process.stdout.write(`Converting frames to webm (File ${index}/${tempFramesFrames.length})...`)
 
@@ -171,7 +171,7 @@ async function main() {
 			case 99:
 				// Since audio frames don't match video frames, this calculates the percentage
 				// through the file a video frame is and grabs the closest audio frame's decibels.
-				const { percentMax } = type.map[Math.max(Math.min(Math.floor(index / (length - 1) * type.mapN), type.mapN), 0)]
+				const { percentMax } = type.audioMap[Math.max(Math.min(Math.floor(index / (length - 1) * type.audioMapL), type.audioMapL), 0)]
 				height = index === 0 ? maxHeight : Math.max(Math.floor(Math.abs(maxHeight * percentMax)), delta)
 				//width = index === 0 ? maxWidth : Math.max(Math.floor(Math.abs(maxWidth * percentMax)), delta)
 				break

--- a/wackywebm.js
+++ b/wackywebm.js
@@ -11,6 +11,9 @@ const fs = require('fs')
 const util = require('util')
 const execSync = util.promisify(require('child_process').exec)
 const getFileName = (p) => path.basename(p, path.extname(p))
+// In case audio level readouts throw an "-inf"
+// this will make it Javascript's negative infinity.
+const resolveNumber = n => isNaN(Number(n)) ? Number.NEGATIVE_INFINITY : Number(n)
 
 if (process.argv.length < 3 || process.argv.length > 4) return displayUsage()
 
@@ -39,6 +42,11 @@ switch (inputType.toLowerCase()) {
 		type.n = 4
 		type.w = 'Shrink'
 		break
+	// Utilized 99 for now until another system is devised.
+	case 'audiophile':
+		type.n = 99
+		type.w = 'Audiophile'
+		break
 	default:
 		rawVideoPath.unshift(inputType)
 }
@@ -66,6 +74,21 @@ function buildLocations() {
 
 function displayUsage() {
 	console.log('WackyWebM by OIRNOIR#0032\nUsage: node wackywebm [optional_type: bounce, shutter, bounce+shutter, sporadic, shrink] <input_file>')
+}
+
+// Obtains a map of the audio levels in decibels from the input file.
+async function getAudioLevelMap() {
+	// The method requires escaping the file path.
+	// Modify this regular expression if more are necessary.
+	const escapePathRegex = /([\\/:])/g
+	const { frames: rawAudioData } = JSON.parse((await execSync(`ffprobe -f lavfi -i "amovie='${videoPath.replace(escapePathRegex, '\\$1')}',astats=metadata=1:reset=1" -show_entries "frame=pkt_pts_time:frame_tags=lavfi.astats.Overall.RMS_level" -of json`)).stdout)
+	// Remap to simplify the format.
+	const intermediateMap = rawAudioData.map(({ tags: { "lavfi.astats.Overall.RMS_level": dBs } }, i) => ({ frame: Number(i + 1), dBs: resolveNumber(dBs) }))
+	// Obtain the highest audio level from the file.
+	const highest = intermediateMap.reduce((previous, current) => (previous.dBs > current.dBs ? previous : current))
+	//return map1.map(v => ({ percentMax: 1 - (highest.dBs / v.dBs), ...v })) // Shrink when louder.
+	// Amend percentages of the audio per frame vs. the highest in the file.
+	return map1.map(v => ({ percentMax: highest.dBs / v.dBs, ...v }))
 }
 
 async function main() {
@@ -117,7 +140,12 @@ async function main() {
 	let index = 0,
 		lines = [],
 		width = maxWidth,
-		height = maxHeight
+		height = maxHeight,
+		length = tempFramesFrames.length
+	if (type.n === 99) {
+		type.map = await getAudioLevelMap()
+		type.mapN = type.map.length - 1
+	}
 	process.stdout.write(`Converting frames to webm (File ${index}/${tempFramesFrames.length})...`)
 
 	for (const { file } of tempFramesFrames) {
@@ -140,6 +168,13 @@ async function main() {
 			case 4:
 				height = Math.max(1, Math.floor(maxHeight - (index / tempFramesFrames.length) * maxHeight))
 				break
+			case 99:
+				// Since audio frames don't match video frames, this calculates the percentage
+				// through the file a video frame is and grabs the closest audio frame's decibels.
+				const { percentMax } = type.map[Math.max(Math.min(Math.floor(index / (length - 1) * type.mapN), type.mapN), 0)]
+				height = index === 0 ? maxHeight : Math.max(Math.floor(Math.abs(maxHeight * percentMax)), delta)
+				//width = index === 0 ? maxWidth : Math.max(Math.floor(Math.abs(maxWidth * percentMax)), delta)
+				break
 		}
 		// Creates the respective resized frame based on the above.
 		await execSync(`ffmpeg -y -i "${path.join(workLocations.tempFrames, file)}" -c:v vp8 -b:v 1M -crf 10 -vf scale=${width}x${height} -aspect ${width}:${height} -r ${framerate} -f webm "${path.join(workLocations.tempResizedFrames, file + '.webm')}"`)
@@ -148,7 +183,7 @@ async function main() {
 		index++
 		process.stdout.clearLine()
 		process.stdout.cursorTo(0)
-		process.stdout.write(`Converting frames to webm (File ${index}/${tempFramesFrames.length})...`)
+		process.stdout.write(`Converting frames to webm (File ${index}/${length})...`)
 	}
 	process.stdout.write('\n')
 


### PR DESCRIPTION
Added a mode (Audiophile) where the outputted video's height is relative to the current audio level verses the highest within the video. It's pretty dirty, but it works.