### PR TITLE
Add Audio-Shutter and refactor modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ You can also tweak the script to taste if you want to adjust how your file is ge
 - `Bounce+Shutter`: The simultaneous effects of `Bounce` and `Shutter`, slightly offset from each other.
 - `Sporadic`: The video glitches and wobbles randomly.
 - `Shrink`: The video shrinks vertically until it's just one pixel thin.
-- `Audiophile`: The video's vertical height changes relative to the current audio level verses the highest within the video.
+- `Audio-Bounce`: The video's vertical height changes relative to the current audio level verses the highest within the video.
+- `Audio-Shutter`: The video's horizontal width changes relative to the current audio level verses the highest within the video.

--- a/wackywebm.js
+++ b/wackywebm.js
@@ -22,7 +22,12 @@ const modes = ['Bounce', 'Shutter', 'Sporadic', 'Bounce+Shutter', 'Shrink', 'Aud
 // Process input arguments. Assume first argument is the desired output type, and if
 // it matches none, assume part of the rawVideoPath and unshift it back before joining.
 const [inputType, ...rawVideoPath] = process.argv.slice(2),
-	type = { w: modes.find((m) => m.toLowerCase() == inputType.toLowerCase())?.replace(/\+/g, '_') ?? 'Bounce' }
+	type = { w: modes.find((m) => m.toLowerCase() == inputType.toLowerCase())?.replace(/\+/g, '_') }
+
+if (type.w == undefined) {
+	rawVideoPath.unshift(inputType)
+	type.w = 'Bounce' // Default type
+}
 
 const videoPath = rawVideoPath.join(' ').trim()
 const fileName = getFileName(videoPath),


### PR DESCRIPTION
I'm adding an Audio-Shutter mode based on the existing `audiophile` mode, and renaming the latter to Audio-Bounce.

I also changed the way modes are stored and chosen to use strings, for easier scalability for the ever-expanding number of modes we'll have.