### PR TITLE
only create new webm file if size actually changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ If you're on MacOS or Linux, you can run `run.sh`. You may have to give it permi
 
 You can also tweak the script to taste if you want to adjust how your file is generated.
 
-You can also change the bitrate of the output file by tweaking `-b` (Default is 1M, which means 1 MB/s. If the file is too large, consider lowering this value.)
+If the file is too large, consider increasing the compression value `-c <number>` - the higher it is, the less "smooth" the size change will be, but file size may sink drastically.
+
+Additionally, you may also change the bitrate of the output file by tweaking `-b` (Default is 1M, which means 1 MB/s)
 
 ## Mode options
 

--- a/wackywebm.js
+++ b/wackywebm.js
@@ -133,6 +133,7 @@ function displayUsage() {
 	const Usage =
 		'WackyWebM by OIRNOIR#0032\n' +
 		'Usage: node wackywebm.js [-o output_file_path] [optional_type] [-k keyframe_file] <input_file>\n' +
+		'\t-c,--compression: change compression level (higher is more compressed, 0 is lossless)\n' +
 		'\t-o,--output: change output file path (needs the desired output path as an argument)\n' +
 		'\t-k,--keyframes: only required with the type set to "Keyframes", sets the path to the keyframe file\n' +
 		'\t-b,--bitrate: change the bitrate used to encode the file (Default is 1 MB/s)\n' +


### PR DESCRIPTION
this is by far the most effective if, for a decent bit of the video, the size stays constant (for example, with some keyframe configurations or a silent part in audio). In the former case, ive managed to reduce file sizes from `14` to `1.2` MB, and reduce the time the "converting frames to webm" step takes by (very roughly) a factor of 10.

TODO:
- [x] ~~compression option to allow for minor variations (maybe +/- 2 pixels) in size without creating new webm, at the cost of smoothness of the size change~~